### PR TITLE
Store usage statistics on the competitions row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,4 +77,12 @@ Human-readable segment names aren't in filenames; they're extracted from line 2 
 
 ## Branch / Deploy Strategy
 
-`test` → `main` promote via PRs. `.github/workflows/deploy.yml` deploys infra (Bicep), backend, and frontend to the matching GitHub environment: **push to `main` auto-deploys prod**; **`test` is manual-only** via `workflow_dispatch` (run the workflow from the branch whose code you want, pick the environment) — there is no `test`-branch push trigger. This mirrors the figureskatingtools-site repo. The workflow also patches the Entra app registration (redirect URIs, federated identity credential) and disables the Easy Auth token store.
+`test` → `main` promote via PRs, merged with **squash** (one commit per release on `main`). `.github/workflows/deploy.yml` deploys infra (Bicep), backend, and frontend to the matching GitHub environment: **push to `main` auto-deploys prod**; **`test` is manual-only** via `workflow_dispatch` (run the workflow from the branch whose code you want, pick the environment) — there is no `test`-branch push trigger. This mirrors the figureskatingtools-site repo. The workflow also patches the Entra app registration (redirect URIs, federated identity credential) and disables the Easy Auth token store.
+
+**After every squash-merge to `main`, reset `test` to `main`** — squash creates a new commit on `main`, so without this every future PR re-lists all old commits:
+
+```bash
+git checkout test && git fetch && git reset --hard origin/main && git push --force origin test
+```
+
+When asked to create a `test` → `main` PR: create it, then ask whether it has been merged (it's usually checked and squash-merged almost immediately) and run the reset above once it is. Verify before resetting that `git diff origin/main origin/test` is empty.

--- a/infra/functions/combine_judging_papers.py
+++ b/infra/functions/combine_judging_papers.py
@@ -145,3 +145,5 @@ def merge_pdfs(output_path, file_list):
     with open(output_path, "wb") as f:
         writer.write(f)
     print(f"Created: {output_path}")
+    # Page count of the merged PDF — used by the processor for usage statistics.
+    return len(writer.pages)

--- a/infra/functions/function_app.py
+++ b/infra/functions/function_app.py
@@ -229,6 +229,60 @@ def _bump_competition_counters(comp_id, uploaded_delta=0, generate_delta=0, set_
         logging.warning(f"Failed to update counters for competition {comp_id}: {e}")
 
 
+def _store_competition_statistics(comp_id, stats):
+    """
+    Best-effort write of the usage-statistics snapshot (returned by the
+    processor) onto the competitions entity. Overwrites the previous snapshot;
+    only TotalPagesGenerated accumulates across generate runs.
+    Never raises — statistics failures must not fail the user's operation.
+    """
+    if not stats:
+        return
+    try:
+        comp_table = get_table_client("competitions")
+        if not comp_table:
+            return
+        entity = comp_table.get_entity(partition_key="GLOBAL", row_key=comp_id)
+
+        pages = int(stats.get("pages_generated", 0))
+        update = {
+            "PartitionKey": "GLOBAL",
+            "RowKey": comp_id,
+            "PagesGenerated": pages,
+            "TotalPagesGenerated": int(entity.get("TotalPagesGenerated", 0)) + pages,
+            "LastStatisticsDate": f"{datetime.utcnow().isoformat()}Z",
+        }
+
+        # snake_case stats key -> (PascalCase column, JSON-encode?)
+        column_map = {
+            "competition_type": ("CompetitionType", False),
+            "categories": ("CategoriesJson", True),
+            "category_count": ("CategoryCount", False),
+            "competitor_count": ("CompetitorCount", False),
+            "segment_count": ("SegmentCount", False),
+            "segment_types": ("SegmentTypesJson", True),
+            "judge_assignment_count": ("JudgeAssignmentCount", False),
+            "unique_judge_count": ("UniqueJudgeCount", False),
+            "unique_official_count": ("UniqueOfficialCount", False),
+            "officials_by_role": ("OfficialsByRoleJson", True),
+            "withdrawn_count": ("WithdrawnCount", False),
+            "day_count": ("CompetitionDayCount", False),
+            "first_date": ("FirstCompetitionDate", False),
+            "last_date": ("LastCompetitionDate", False),
+            "judging_method": ("JudgingMethod", False),
+            "language": ("PacketLanguage", False),
+        }
+        for key, (column, as_json) in column_map.items():
+            value = stats.get(key)
+            if value is None:
+                continue  # skip unknowns (e.g. CompetitorCount without a schedule)
+            update[column] = json.dumps(value, ensure_ascii=False) if as_json else value
+
+        comp_table.update_entity(update, mode=UpdateMode.MERGE)
+    except Exception as e:
+        logging.warning(f"Failed to store statistics for competition {comp_id}: {e}")
+
+
 def migrate_legacy_row(comp_table, entity):
     """
     Migrate a legacy competitions row (RowKey = competition name, name-based blob
@@ -1019,7 +1073,7 @@ def generate_judging_papers(req: func.HttpRequest) -> func.HttpResponse:
 
         # Run the processor
         logging.info("Running processor...")
-        process_judging_papers(source_dir, output_dir, options=options)
+        stats = process_judging_papers(source_dir, output_dir, options=options)
 
         # Upload results
         logging.info("Uploading results...")
@@ -1046,6 +1100,7 @@ def generate_judging_papers(req: func.HttpRequest) -> func.HttpResponse:
         logging.info(f"Uploaded {upload_count} files.")
 
         _bump_competition_counters(comp_id, generate_delta=1, set_last_generated=True)
+        _store_competition_statistics(comp_id, stats or {})
 
         return func.HttpResponse(f"Successfully processed {download_count} files and generated {upload_count} output files.", status_code=200)
 

--- a/infra/functions/processor.py
+++ b/infra/functions/processor.py
@@ -318,6 +318,7 @@ def process_judging_papers(source_dir, output_dir, options=None):
     print("\n[3/5] Combining Papers...")
     
     count = 0
+    total_pages = 0  # pages across per-person packets (for usage statistics)
     for date_str, persons in person_tasks.items():
         for slug, data in persons.items():
             tasks = data['tasks']
@@ -476,7 +477,7 @@ def process_judging_papers(source_dir, output_dir, options=None):
             output_path = os.path.join(output_dir, output_filename)
             
             print(f"  Creating {output_filename}...")
-            merge_pdfs(output_path, file_list)
+            total_pages += merge_pdfs(output_path, file_list) or 0
             count += 1
 
     # ---------------------------------------------------------
@@ -531,3 +532,119 @@ def process_judging_papers(source_dir, output_dir, options=None):
                     print(f"  Error deleting {filepath}: {e}")
 
     print(f"\nDone! Created judging paper files and daily summaries in '{output_dir}'.")
+
+    # ---------------------------------------------------------
+    # 6. Compute usage statistics (best-effort, never raises)
+    # ---------------------------------------------------------
+    try:
+        stats = _compute_statistics(
+            categories, schedule_entries, person_tasks, prefix_withdrawn,
+            language, total_pages
+        )
+    except Exception as e:
+        print(f"  Warning: Failed to compute statistics: {e}")
+        stats = {}
+
+    return stats
+
+
+def _compute_statistics(categories, schedule_entries, person_tasks, prefix_withdrawn,
+                        language, total_pages):
+    """
+    Build a usage-statistics dict from the structures accumulated during
+    process_judging_papers. Stored on the competitions table row (which
+    survives soft-deletion) for a future statistics page.
+    """
+    # Distinct prefixes (segments) actually processed, from post-conflict-filter tasks
+    prefixes = set()
+    role_slugs = {}        # role bucket -> set of person slugs
+    judge_slugs = set()    # slugs holding role 'judge'
+    all_slugs = set()      # slugs across all roles
+    judge_assignment_count = 0
+    role_buckets = {
+        'referee': 'referees',
+        'technical_controller': 'technical_controllers',
+        'technical_specialist_1': 'technical_specialists',
+        'technical_specialist_2': 'technical_specialists',
+        'data_operator': 'data_operators',
+        'replay_operator': 'replay_operators',
+    }
+
+    for date_str, persons in person_tasks.items():
+        for slug, data in persons.items():
+            all_slugs.add(slug)
+            for prefix, role in data['tasks']:
+                prefixes.add(prefix)
+                if role == 'judge':
+                    judge_slugs.add(slug)
+                    judge_assignment_count += 1
+                elif role in role_buckets:
+                    role_slugs.setdefault(role_buckets[role], set()).add(slug)
+
+    officials_by_role = {bucket: len(slugs) for bucket, slugs in sorted(role_slugs.items())}
+
+    # Categories / segment types / competition type / judging method per prefix
+    category_names = set()
+    competition_types = set()
+    judging_methods = set()
+    segment_types = set()
+    for prefix in prefixes:
+        matched = match_category(prefix, categories)
+        if matched:
+            if language == "en":
+                category_names.add(matched["displayName"])
+            else:
+                category_names.add(matched.get("displayNameFi", matched["displayName"]))
+            competition_types.add(matched["competitionType"])
+            judging_methods.add(matched["judgingMethod"])
+        _, segment = parse_prefix(prefix, categories, language=language)
+        if segment and segment != "Category General":
+            segment_types.add(segment)
+
+    def _single_or_mixed(values):
+        values = {v for v in values if v}
+        if not values:
+            return None
+        return values.pop() if len(values) == 1 else "Mixed"
+
+    # Competitor count: per category, the largest segment entry count from the
+    # schedule (same field skates SP and FS), summed across categories.
+    competitor_count = None
+    if schedule_entries:
+        per_category_max = {}
+        for entry in schedule_entries:
+            key = entry.get("category_name") or entry.get("event_name", "")
+            per_category_max[key] = max(per_category_max.get(key, 0), entry.get("entries", 0))
+        competitor_count = sum(per_category_max.values())
+
+    # Competition days: prefer panel-derived dates, fall back to schedule dates
+    dates = sorted(person_tasks.keys())
+    if not dates and schedule_entries:
+        dates = sorted({e["date"] for e in schedule_entries if e.get("date")})
+
+    def _iso_date(yyyymmdd):
+        return f"{yyyymmdd[:4]}-{yyyymmdd[4:6]}-{yyyymmdd[6:8]}" if len(yyyymmdd) == 8 else yyyymmdd
+
+    # Withdrawn entries are counted per segment: a skater withdrawing from both
+    # SP and FS counts twice (this measures withdrawn entries, not persons).
+    withdrawn_count = sum(len(v) for v in prefix_withdrawn.values())
+
+    return {
+        "competition_type": _single_or_mixed(competition_types),
+        "categories": sorted(category_names),
+        "category_count": len(category_names),
+        "competitor_count": competitor_count,
+        "segment_count": len(prefixes),
+        "segment_types": sorted(segment_types),
+        "judge_assignment_count": judge_assignment_count,
+        "unique_judge_count": len(judge_slugs),
+        "unique_official_count": len(all_slugs),
+        "officials_by_role": officials_by_role,
+        "withdrawn_count": withdrawn_count,
+        "day_count": len(dates),
+        "first_date": _iso_date(dates[0]) if dates else None,
+        "last_date": _iso_date(dates[-1]) if dates else None,
+        "judging_method": _single_or_mixed(judging_methods),
+        "language": language,
+        "pages_generated": total_pages,
+    }


### PR DESCRIPTION
## Summary
- `process_judging_papers` now returns a statistics dict computed from structures the pipeline already builds: competition type, categories list/count, competitor count (per-category max of schedule entries), segment count + distinct segment types, judge assignments vs unique judges, unique officials with per-role breakdown, withdrawn entries, competition day count + first/last date, judging method (ISU/MUPI/Mixed), packet language, and pages generated (per-person packets; `merge_pdfs` now returns its page count)
- New best-effort `_store_competition_statistics` helper MERGEs the snapshot onto the permanent `competitions` row after each generate run — latest run overwrites, only `TotalPagesGenerated` accumulates; stats survive competition soft-deletion for a future statistics page
- `CompetitorCount` is omitted (not 0) when no CompetitionSchedule is uploaded; stats failures never fail the user's generate operation
- Also includes the squash-merge promote flow documentation commit

## Test plan
- [x] Deployed to test environment via workflow_dispatch and verified with a real generate run
- [x] Unit-level checks: per-category-max competitor count, None-skipping in the MERGE update, `TotalPagesGenerated` accumulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)