### PR TITLE
Add Dependabot config: weekly grouped updates targeting test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+# Dependabot version updates. Weekly, grouped into one PR per ecosystem,
+# targeting `test` so updates flow through the normal test -> verify ->
+# promote-to-main process instead of auto-deploying prod on merge.
+#
+# NOTE: this file is only read from the default branch (main).
+# NOTE: resolving @figureskatingtools/shared-ui from GitHub Packages requires
+# a Dependabot secret PACKAGES_READ_TOKEN (classic PAT with read:packages),
+# set under Settings -> Secrets and variables -> Dependabot.
+version: 2
+
+registries:
+  github-npm:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{ secrets.PACKAGES_READ_TOKEN }}
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    registries:
+      - github-npm
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Helsinki"
+    target-branch: "test"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/infra/functions"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Helsinki"
+    target-branch: "test"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Helsinki"
+    target-branch: "test"
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly version updates for npm (`frontend/`), pip (`infra/functions/`), and GitHub Actions
- Updates are grouped into one PR per ecosystem and target the `test` branch, so they flow through the normal test → verify → promote process (merging to `main` auto-deploys prod, so Dependabot must not PR main directly)
- Config only takes effect once merged to `main` (Dependabot reads it from the default branch)

## Post-merge requirement
- [ ] Add a Dependabot secret `PACKAGES_READ_TOKEN` (Settings → Secrets and variables → **Dependabot**) containing a classic PAT with `read:packages`, so Dependabot can resolve `@figureskatingtools/shared-ui` from GitHub Packages. Without it the npm updates will fail (pip and actions updates work regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)