### PR TITLE
Promote test → main: bump shared-ui to 2.2.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fs-judge-papers-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@figureskatingtools/shared-ui": "^2.0.5"
+        "@figureskatingtools/shared-ui": "^2.2.0"
       },
       "devDependencies": {
         "@azure/static-web-apps-cli": "^2.0.8",
@@ -919,9 +919,9 @@
       }
     },
     "node_modules/@figureskatingtools/shared-ui": {
-      "version": "2.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@figureskatingtools/shared-ui/2.1.0/b1b6a05c728aa1998985ca2dc4cae5a704484f94",
-      "integrity": "sha512-qLfxhdxdIxUjkW1B9VoaX0iV4xXY+dbjTdO85gpjg5l9GBQAyd+n8vmA8S3DDcbbdM2PVVyZHmiS3qMOJvAQnQ==",
+      "version": "2.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@figureskatingtools/shared-ui/2.2.0/463c0ff9853381a0cff8e504332a51f86c7d1449",
+      "integrity": "sha512-4nqYCXNVkDj/DewGvjcCrR+tOlwh+dP07e/N1AeYo1asm12n+EcE/QRxH8tMoh65N8i/y0lR/schwKSdtVIVFw==",
       "license": "MIT"
     },
     "node_modules/@hapi/hoek": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@figureskatingtools/shared-ui": "^2.0.5"
+    "@figureskatingtools/shared-ui": "^2.2.0"
   },
   "overrides": {
     "tmp": "^0.2.7"


### PR DESCRIPTION
Promote `test` to `main`.

- Bump shared-ui to 2.2.0 (activates Score Modifier in nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)