### PR TITLE
Update shared-ui to 2.3.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fs-judge-papers-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@figureskatingtools/shared-ui": "^2.2.0"
+        "@figureskatingtools/shared-ui": "^2.3.0"
       },
       "devDependencies": {
         "@azure/static-web-apps-cli": "^2.0.10",
@@ -477,9 +477,9 @@
       }
     },
     "node_modules/@figureskatingtools/shared-ui": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@figureskatingtools/shared-ui/2.2.0/463c0ff9853381a0cff8e504332a51f86c7d1449",
-      "integrity": "sha512-4nqYCXNVkDj/DewGvjcCrR+tOlwh+dP07e/N1AeYo1asm12n+EcE/QRxH8tMoh65N8i/y0lR/schwKSdtVIVFw==",
+      "version": "2.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@figureskatingtools/shared-ui/2.3.0/055673c968d226dfcbd10fee804300ce11a18f2e",
+      "integrity": "sha512-WPt0RmhIO+Ip7RMG5RES94t+dFM6hHiCjln+BWlXjqmLXW7j8ai+piHkuLMbCdHQ7z7IzHFWt6vQJAnZPhgiuw==",
       "license": "MIT"
     },
     "node_modules/@hapi/hoek": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@figureskatingtools/shared-ui": "^2.2.0"
+    "@figureskatingtools/shared-ui": "^2.3.0"
   },
   "overrides": {
     "tmp": "^0.2.7",


### PR DESCRIPTION
Bumps @figureskatingtools/shared-ui from 2.2.0 to 2.3.0 in the frontend. Build verified and deployed to the test environment via workflow_dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)